### PR TITLE
Future/#28

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,0 +1,3 @@
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+SUPABASE_JWT_AUDIENCE=authenticated

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,28 +1,60 @@
-Prerequisites:
+# Backend（Hono API）
 
-- [Vercel CLI](https://vercel.com/docs/cli) installed globally
+`Issue #14` 対応として、backend は Supabase DB への CRUD と JWT 検証（JWKS）を実装しています。
 
-To develop locally:
+## 前提
 
-```
-npm install
-vc dev
+- Node.js / pnpm
+- Docker Desktop
+- Supabase CLI（グローバル）または `pnpm dlx supabase`
+- Vercel CLI（`vercel dev` を使う場合）
+
+## 環境変数
+
+PowerShell例:
+
+```powershell
+$env:SUPABASE_URL="http://127.0.0.1:54321"
+$env:SUPABASE_SERVICE_ROLE_KEY="<service_role_key>"
+$env:SUPABASE_JWT_AUDIENCE="authenticated"
 ```
 
-```
-open http://localhost:3000
+- `SUPABASE_URL`: Supabase API URL
+- `SUPABASE_SERVICE_ROLE_KEY`: サービスロールキー（DB操作用）
+- `SUPABASE_JWT_AUDIENCE`: JWTの `aud` 検証値（未指定時 `authenticated`）
+
+## ローカル起動手順
+
+1. 依存インストール
+
+```powershell
+Set-Location C:\.program_code\megalo2026
+pnpm install
 ```
 
-To build locally:
+2. Supabase 起動・DB反映
 
-```
-npm install
-vc build
+```powershell
+pnpm dlx supabase start
+pnpm dlx supabase db reset
+pnpm dlx supabase status
 ```
 
-To deploy:
+3. backend 起動（Vercel dev）
 
+```powershell
+Set-Location C:\.program_code\megalo2026\apps\backend
+pnpm dlx vercel dev --listen 8787
 ```
-npm install
-vc deploy
+
+補助として、Hono を直接起動する場合:
+
+```powershell
+pnpm dev
 ```
+
+## API認証メモ
+
+- `Authorization: Bearer <JWT>` を必要とするAPIは、Supabase JWKSで署名検証します。
+- トークンなし/無効トークンの場合は `401 Unauthorized` を返します。
+- `POST /api/stages/:id/play_logs` のみ認証任意です（未認証時 `player_id = null`）。

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,8 +1,14 @@
 {
   "name": "hono",
   "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
   "dependencies": {
-    "hono": "^4.12.8"
+    "@supabase/supabase-js": "^2.99.2",
+    "hono": "^4.12.8",
+    "jose": "^6.2.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,162 +1,68 @@
-import { Hono } from 'hono'
+import { createClient, type PostgrestError } from '@supabase/supabase-js'
+import { createRemoteJWKSet, jwtVerify } from 'jose'
+import { Hono, type Context, type MiddlewareHandler } from 'hono'
 import { cors } from 'hono/cors'
-import type { StageData } from './types/stage.js'
+import { createEmptyStageData, isStageData } from './types/stage.js'
+import type { Database } from './types/database.js'
 
-type GimmickKind = StageData['gimmicks'][number]['kind']
-
-interface Profile {
-  id: string
-  display_name: string
-  created_at: string
-}
-
-interface StageRecord {
-  id: string
-  author_id: string
-  title: string
-  stage_data: StageData
-  is_published: boolean
-  play_count: number
-  clear_count: number
-  like_count: number
-  created_at: string
-  updated_at: string
-}
-
-type StageListItem = Omit<StageRecord, 'stage_data'>
-
-const app = new Hono()
-
-const allowedOrigins = ['http://localhost:5173', 'http://127.0.0.1:5173']
-const defaultAuthorId = 'user-0001'
-const mockNow = '2026-03-16T00:00:00.000Z'
-
-const mockProfile: Profile = {
-  id: defaultAuthorId,
-  display_name: 'mock-player',
-  created_at: '2026-01-01T00:00:00.000Z',
-}
-
-const createMockId = (prefix: string): string =>
-  `${prefix}-${Math.random().toString(36).slice(2, 10)}`
-
-const createMockStageData = (seed: number): StageData => {
-  const gimmickKindCycle: GimmickKind[] = ['wall', 'fan', 'spring', 'spike', 'wave']
-  const gimmickKind = gimmickKindCycle[seed % gimmickKindCycle.length]
-
-  return {
-    version: '1.0.0',
-    world: {
-      width: 1920,
-      height: 1080,
-      gridSize: 16,
-    },
-    physics: {
-      gravity: { x: 0, y: 9.8 },
-      airDrag: 0.02,
-      windDecay: 0.9,
-      windForceScale: 1 + seed * 0.05,
-    },
-    spawn: {
-      position: { x: 120 + seed * 4, y: 100 },
-    },
-    goal: {
-      position: { x: 1720 - seed * 10, y: 920 },
-      size: { width: 100, height: 100 },
-    },
-    gimmicks: [
-      {
-        id: `wall-${seed}`,
-        kind: 'wall',
-        position: { x: 960, y: 1040 },
-        size: { width: 1800, height: 40 },
-      },
-      gimmickKind === 'fan'
-        ? {
-            id: `fan-${seed}`,
-            kind: 'fan',
-            position: { x: 480, y: 840 },
-            force: 15 + seed,
-            range: 320,
-            direction: { x: 1, y: 0 },
-          }
-        : gimmickKind === 'spring'
-          ? {
-              id: `spring-${seed}`,
-              kind: 'spring',
-              position: { x: 520, y: 920 },
-              size: { width: 80, height: 40 },
-              power: 18 + seed,
-            }
-          : gimmickKind === 'spike'
-            ? {
-                id: `spike-${seed}`,
-                kind: 'spike',
-                position: { x: 760, y: 960 },
-                size: { width: 120, height: 32 },
-                damage: 1,
-              }
-            : {
-                id: `wave-${seed}`,
-                kind: 'wave',
-                position: { x: 640, y: 760 },
-                length: 300,
-                amplitude: 24,
-                frequency: 0.08,
-                speed: 1.2,
-              },
-    ],
+type AppBindings = {
+  Variables: {
+    authUserId: string | null
   }
 }
 
-const mockStages: StageRecord[] = [
-  {
-    id: 'stage-0001',
-    author_id: defaultAuthorId,
-    title: 'はじめての風チュートリアル',
-    stage_data: createMockStageData(1),
-    is_published: true,
-    play_count: 120,
-    clear_count: 88,
-    like_count: 42,
-    created_at: '2026-02-01T00:00:00.000Z',
-    updated_at: '2026-03-10T00:00:00.000Z',
-  },
-  {
-    id: 'stage-0002',
-    author_id: defaultAuthorId,
-    title: 'ばねコンボ練習場',
-    stage_data: createMockStageData(2),
-    is_published: false,
-    play_count: 15,
-    clear_count: 4,
-    like_count: 3,
-    created_at: '2026-02-20T00:00:00.000Z',
-    updated_at: '2026-03-05T00:00:00.000Z',
-  },
-  {
-    id: 'stage-0003',
-    author_id: 'user-9999',
-    title: '送風機タイムアタック',
-    stage_data: createMockStageData(3),
-    is_published: true,
-    play_count: 300,
-    clear_count: 120,
-    like_count: 75,
-    created_at: '2026-01-21T00:00:00.000Z',
-    updated_at: '2026-03-15T00:00:00.000Z',
-  },
-]
+type AppContext = Context<AppBindings>
+type ErrorStatus = 400 | 401 | 403 | 404 | 500
+type StageRecord = Database['public']['Tables']['stages']['Row']
+type StageListItem = Omit<StageRecord, 'stage_data'>
 
-const toStageListItem = ({ stage_data: _stageData, ...stage }: StageRecord): StageListItem =>
-  stage
+const STAGE_LIST_SELECT =
+  'id,author_id,title,is_published,play_count,clear_count,like_count,created_at,updated_at'
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key)
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isUuid = (value: string): boolean => UUID_PATTERN.test(value)
+
+const getRequiredEnv = (name: string): string => {
+  const value = process.env[name]?.trim()
+  if (!value) {
+    throw new Error(`環境変数 ${name} が未設定です。`)
+  }
+  return value
+}
+
+const normalizeSupabaseUrl = (value: string): string => value.replace(/\/+$/, '')
+
+const supabaseUrl = normalizeSupabaseUrl(getRequiredEnv('SUPABASE_URL'))
+const supabaseServiceRoleKey = getRequiredEnv('SUPABASE_SERVICE_ROLE_KEY')
+const supabaseJwtAudience = process.env.SUPABASE_JWT_AUDIENCE?.trim() || 'authenticated'
+const supabaseJwtIssuer = `${supabaseUrl}/auth/v1`
+const supabaseJwks = createRemoteJWKSet(
+  new URL(`${supabaseJwtIssuer}/.well-known/jwks.json`),
+)
+
+const supabase = createClient<Database>(supabaseUrl, supabaseServiceRoleKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+})
+
+const app = new Hono<AppBindings>()
+
+const allowedOrigins = ['http://localhost:5173', 'http://127.0.0.1:5173']
 
 const parsePositiveInt = (value: string | undefined, fallback: number): number => {
   const parsed = Number(value)
   if (!Number.isInteger(parsed) || parsed <= 0) {
     return fallback
   }
-
   return parsed
 }
 
@@ -170,8 +76,125 @@ const parseBoolean = (value: string | undefined): boolean | undefined => {
   if (value === 'false') {
     return false
   }
-
   return undefined
+}
+
+const readJsonObject = async (c: AppContext): Promise<Record<string, unknown> | Response> => {
+  try {
+    const body = await c.req.json<unknown>()
+    if (!isRecord(body)) {
+      return c.json({ error: 'リクエストボディはJSONオブジェクトである必要があります。' }, 400)
+    }
+    return body
+  } catch {
+    return c.json({ error: 'JSONのパースに失敗しました。' }, 400)
+  }
+}
+
+const jsonError = (c: AppContext, status: ErrorStatus, message: string): Response =>
+  c.json({ error: message }, status)
+
+const dbError = (
+  c: AppContext,
+  error: PostgrestError | null,
+  contextMessage: string,
+): Response =>
+  jsonError(c, 500, `${contextMessage}: ${error?.message ?? '不明なDBエラーです。'}`)
+
+const toStageListItem = ({ stage_data: _stageData, ...stage }: StageRecord): StageListItem =>
+  stage
+
+const extractBearerToken = (authorizationHeader: string | undefined): string | null => {
+  if (!authorizationHeader) {
+    return null
+  }
+  const matched = authorizationHeader.match(/^Bearer\s+(.+)$/i)
+  if (!matched) {
+    return null
+  }
+  const token = matched[1].trim()
+  return token.length > 0 ? token : null
+}
+
+const verifyAccessToken = async (token: string): Promise<string | null> => {
+  try {
+    const { payload } = await jwtVerify(token, supabaseJwks, {
+      issuer: supabaseJwtIssuer,
+      audience: supabaseJwtAudience,
+    })
+    if (typeof payload.sub !== 'string' || !isUuid(payload.sub)) {
+      return null
+    }
+    return payload.sub
+  } catch {
+    return null
+  }
+}
+
+const requireAuth: MiddlewareHandler<AppBindings> = async (c, next) => {
+  const token = extractBearerToken(c.req.header('Authorization'))
+  if (!token) {
+    return jsonError(c, 401, '認証トークンが必要です。')
+  }
+
+  const userId = await verifyAccessToken(token)
+  if (!userId) {
+    return jsonError(c, 401, '認証トークンが無効です。')
+  }
+
+  c.set('authUserId', userId)
+  await next()
+}
+
+const optionalAuth: MiddlewareHandler<AppBindings> = async (c, next) => {
+  const token = extractBearerToken(c.req.header('Authorization'))
+  if (!token) {
+    c.set('authUserId', null)
+    await next()
+    return
+  }
+
+  const userId = await verifyAccessToken(token)
+  if (!userId) {
+    return jsonError(c, 401, '認証トークンが無効です。')
+  }
+
+  c.set('authUserId', userId)
+  await next()
+}
+
+const getAuthUserId = (c: AppContext): string | null => c.get('authUserId')
+
+const parseStageId = (c: AppContext): string | Response => {
+  const stageId = c.req.param('id')
+  if (!stageId || !isUuid(stageId)) {
+    return jsonError(c, 400, 'stage id はUUID形式で指定してください。')
+  }
+  return stageId
+}
+
+const ensureStageOwner = async (
+  c: AppContext,
+  stageId: string,
+  userId: string,
+): Promise<{ stage: { id: string; author_id: string } } | Response> => {
+  const { data: stage, error } = await supabase
+    .from('stages')
+    .select('id,author_id')
+    .eq('id', stageId)
+    .maybeSingle()
+
+  if (error) {
+    return dbError(c, error, 'ステージ情報の取得に失敗しました')
+  }
+  if (!stage) {
+    return jsonError(c, 404, '対象ステージが存在しません。')
+  }
+  if (stage.author_id !== userId) {
+    return jsonError(c, 403, '他ユーザーのステージは操作できません。')
+  }
+
+  return { stage }
 }
 
 app.use(
@@ -183,62 +206,142 @@ app.use(
   }),
 )
 
-app.get('/', (c) => c.text('Mock API server for Issue #9 is running.'))
+app.get('/', (c) => c.text('API server for Issue #14 is running.'))
 
-app.get('/api/profiles/me', (c) =>
-  c.json({
-    data: mockProfile,
-  }),
-)
+app.get('/api/profiles/me', requireAuth, async (c) => {
+  const userId = getAuthUserId(c)
+  if (!userId) {
+    return jsonError(c, 401, '認証情報の取得に失敗しました。')
+  }
 
-app.put('/api/profiles/me', async (c) => {
-  const body = await c.req.json<{ display_name?: string }>()
-  const displayName = body.display_name?.trim() || mockProfile.display_name
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', userId)
+    .maybeSingle()
+
+  if (error) {
+    return dbError(c, error, 'プロフィール取得に失敗しました')
+  }
+  if (!profile) {
+    return jsonError(c, 404, 'プロフィールが見つかりません。')
+  }
+
+  return c.json({ data: profile })
+})
+
+app.put('/api/profiles/me', requireAuth, async (c) => {
+  const userId = getAuthUserId(c)
+  if (!userId) {
+    return jsonError(c, 401, '認証情報の取得に失敗しました。')
+  }
+
+  const bodyResult = await readJsonObject(c)
+  if (bodyResult instanceof Response) {
+    return bodyResult
+  }
+
+  const rawDisplayName = bodyResult.display_name
+  if (typeof rawDisplayName !== 'string') {
+    return jsonError(c, 400, 'display_name は文字列で指定してください。')
+  }
+  const displayName = rawDisplayName.trim()
+  if (displayName.length === 0) {
+    return jsonError(c, 400, 'display_name は空文字にできません。')
+  }
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .update({ display_name: displayName })
+    .eq('id', userId)
+    .select('*')
+    .maybeSingle()
+
+  if (error) {
+    return dbError(c, error, 'プロフィール更新に失敗しました')
+  }
+  if (!profile) {
+    return jsonError(c, 404, '更新対象プロフィールが見つかりません。')
+  }
+
+  return c.json({ data: profile })
+})
+
+app.get('/api/profiles/me/likes', requireAuth, async (c) => {
+  const userId = getAuthUserId(c)
+  if (!userId) {
+    return jsonError(c, 401, '認証情報の取得に失敗しました。')
+  }
+
+  const { data: likes, error: likesError } = await supabase
+    .from('likes')
+    .select('stage_id,created_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+
+  if (likesError) {
+    return dbError(c, likesError, 'いいね一覧取得に失敗しました')
+  }
+
+  const stageIds = (likes ?? []).map((like) => like.stage_id)
+  if (stageIds.length === 0) {
+    return c.json({ data: [], total: 0 })
+  }
+
+  const { data: stages, error: stagesError } = await supabase
+    .from('stages')
+    .select(STAGE_LIST_SELECT)
+    .in('id', stageIds)
+
+  if (stagesError) {
+    return dbError(c, stagesError, 'いいね済みステージ取得に失敗しました')
+  }
+
+  const stageById = new Map((stages ?? []).map((stage) => [stage.id, stage]))
+  const orderedStages = stageIds
+    .map((stageId) => stageById.get(stageId))
+    .filter((stage): stage is StageListItem => stage !== undefined)
 
   return c.json({
-    data: {
-      ...mockProfile,
-      display_name: displayName,
-      updated_at: mockNow,
-    },
+    data: orderedStages,
+    total: orderedStages.length,
   })
 })
 
-app.get('/api/profiles/me/likes', (c) => {
-  const likedStageIds = new Set(['stage-0001', 'stage-0003'])
-  const likedStages = mockStages
-    .filter((stage) => likedStageIds.has(stage.id))
-    .map(toStageListItem)
-
-  return c.json({
-    data: likedStages,
-    total: likedStages.length,
-  })
-})
-
-app.get('/api/stages', (c) => {
-  const q = c.req.query('q')?.trim().toLowerCase()
+app.get('/api/stages', async (c) => {
+  const q = c.req.query('q')?.trim()
   const authorId = c.req.query('author_id')?.trim()
   const isPublished = parseBoolean(c.req.query('is_published'))
   const page = parsePositiveInt(c.req.query('page'), 1)
   const limit = Math.min(parsePositiveInt(c.req.query('limit'), 10), 50)
   const offset = (page - 1) * limit
 
-  const filtered = mockStages.filter((stage) => {
-    const matchesQuery = q === undefined || stage.title.toLowerCase().includes(q)
-    const matchesAuthor = authorId === undefined || stage.author_id === authorId
-    const matchesPublished =
-      isPublished === undefined || stage.is_published === isPublished
+  let query = supabase
+    .from('stages')
+    .select(STAGE_LIST_SELECT, { count: 'exact' })
+    .order('updated_at', { ascending: false })
+    .range(offset, offset + limit - 1)
 
-    return matchesQuery && matchesAuthor && matchesPublished
-  })
+  if (q && q.length > 0) {
+    query = query.ilike('title', `%${q}%`)
+  }
+  if (authorId && authorId.length > 0) {
+    query = query.eq('author_id', authorId)
+  }
+  if (isPublished !== undefined) {
+    query = query.eq('is_published', isPublished)
+  }
 
-  const paginated = filtered.slice(offset, offset + limit).map(toStageListItem)
-  const total = filtered.length
+  const { data: stages, error, count } = await query
+  if (error) {
+    return dbError(c, error, 'ステージ一覧の取得に失敗しました')
+  }
+
+  const total = count ?? 0
   const totalPages = total === 0 ? 0 : Math.ceil(total / limit)
 
   return c.json({
-    data: paginated,
+    data: stages ?? [],
     pagination: {
       page,
       limit,
@@ -253,126 +356,350 @@ app.get('/api/stages', (c) => {
   })
 })
 
-app.post('/api/stages', async (c) => {
-  const body = await c.req.json<{
-    title?: string
-    stage_data?: StageData
-    is_published?: boolean
-  }>()
+app.post('/api/stages', requireAuth, async (c) => {
+  const userId = getAuthUserId(c)
+  if (!userId) {
+    return jsonError(c, 401, '認証情報の取得に失敗しました。')
+  }
 
-  const stage: StageRecord = {
-    id: createMockId('stage'),
-    author_id: defaultAuthorId,
-    title: body.title?.trim() || 'Untitled Stage',
-    stage_data: body.stage_data ?? createMockStageData(4),
-    is_published: body.is_published ?? false,
-    play_count: 0,
-    clear_count: 0,
-    like_count: 0,
-    created_at: mockNow,
-    updated_at: mockNow,
+  const bodyResult = await readJsonObject(c)
+  if (bodyResult instanceof Response) {
+    return bodyResult
+  }
+
+  if (bodyResult.title !== undefined && typeof bodyResult.title !== 'string') {
+    return jsonError(c, 400, 'title は文字列で指定してください。')
+  }
+  if (bodyResult.is_published !== undefined && typeof bodyResult.is_published !== 'boolean') {
+    return jsonError(c, 400, 'is_published はbooleanで指定してください。')
+  }
+
+  const title =
+    typeof bodyResult.title === 'string' && bodyResult.title.trim().length > 0
+      ? bodyResult.title.trim()
+      : 'Untitled Stage'
+  const stageDataCandidate = bodyResult.stage_data ?? createEmptyStageData()
+  if (!isStageData(stageDataCandidate)) {
+    return jsonError(c, 400, 'stage_data の形式が不正です。')
+  }
+
+  const { data: stage, error } = await supabase
+    .from('stages')
+    .insert({
+      author_id: userId,
+      title,
+      stage_data: stageDataCandidate,
+      is_published: bodyResult.is_published === true,
+    })
+    .select('*')
+    .single()
+
+  if (error) {
+    return dbError(c, error, 'ステージ作成に失敗しました')
+  }
+
+  return c.json(
+    {
+      data: stage,
+      message: 'Stage created.',
+    },
+    201,
+  )
+})
+
+app.get('/api/stages/:id', async (c) => {
+  const stageIdResult = parseStageId(c)
+  if (stageIdResult instanceof Response) {
+    return stageIdResult
+  }
+  const stageId = stageIdResult
+
+  const { data: stage, error } = await supabase
+    .from('stages')
+    .select('*')
+    .eq('id', stageId)
+    .maybeSingle()
+
+  if (error) {
+    return dbError(c, error, 'ステージ取得に失敗しました')
+  }
+  if (!stage) {
+    return jsonError(c, 404, '対象ステージが見つかりません。')
+  }
+
+  return c.json({ data: stage })
+})
+
+app.put('/api/stages/:id', requireAuth, async (c) => {
+  const userId = getAuthUserId(c)
+  if (!userId) {
+    return jsonError(c, 401, '認証情報の取得に失敗しました。')
+  }
+
+  const stageIdResult = parseStageId(c)
+  if (stageIdResult instanceof Response) {
+    return stageIdResult
+  }
+  const stageId = stageIdResult
+
+  const ownerResult = await ensureStageOwner(c, stageId, userId)
+  if (ownerResult instanceof Response) {
+    return ownerResult
+  }
+
+  const bodyResult = await readJsonObject(c)
+  if (bodyResult instanceof Response) {
+    return bodyResult
+  }
+
+  const updates: Database['public']['Tables']['stages']['Update'] = {}
+
+  if (hasOwn(bodyResult, 'title')) {
+    if (typeof bodyResult.title !== 'string') {
+      return jsonError(c, 400, 'title は文字列で指定してください。')
+    }
+    const title = bodyResult.title.trim()
+    if (title.length === 0) {
+      return jsonError(c, 400, 'title は空文字にできません。')
+    }
+    updates.title = title
+  }
+
+  if (hasOwn(bodyResult, 'stage_data')) {
+    if (!isStageData(bodyResult.stage_data)) {
+      return jsonError(c, 400, 'stage_data の形式が不正です。')
+    }
+    updates.stage_data = bodyResult.stage_data
+  }
+
+  if (hasOwn(bodyResult, 'is_published')) {
+    if (typeof bodyResult.is_published !== 'boolean') {
+      return jsonError(c, 400, 'is_published はbooleanで指定してください。')
+    }
+    updates.is_published = bodyResult.is_published
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return jsonError(c, 400, '更新対象フィールドがありません。')
+  }
+
+  const { data: updatedStage, error: updateError } = await supabase
+    .from('stages')
+    .update(updates)
+    .eq('id', ownerResult.stage.id)
+    .select('*')
+    .single()
+
+  if (updateError) {
+    return dbError(c, updateError, 'ステージ更新に失敗しました')
   }
 
   return c.json({
-    data: stage,
-    message: 'Mock stage created.',
+    data: updatedStage,
+    message: 'Stage updated.',
   })
 })
 
-app.get('/api/stages/:id', (c) => {
-  const id = c.req.param('id')
-  const stage = mockStages.find((item) => item.id === id)
+app.delete('/api/stages/:id', requireAuth, async (c) => {
+  const userId = getAuthUserId(c)
+  if (!userId) {
+    return jsonError(c, 401, '認証情報の取得に失敗しました。')
+  }
 
-  if (stage) {
-    return c.json({ data: stage })
+  const stageIdResult = parseStageId(c)
+  if (stageIdResult instanceof Response) {
+    return stageIdResult
+  }
+  const stageId = stageIdResult
+
+  const ownerResult = await ensureStageOwner(c, stageId, userId)
+  if (ownerResult instanceof Response) {
+    return ownerResult
+  }
+
+  const { error } = await supabase.from('stages').delete().eq('id', ownerResult.stage.id)
+  if (error) {
+    return dbError(c, error, 'ステージ削除に失敗しました')
   }
 
   return c.json({
     data: {
-      ...mockStages[0],
-      id,
-      title: `Mock Stage ${id}`,
-      stage_data: createMockStageData(9),
-    } satisfies StageRecord,
-    message: 'Requested stage was not found in mock list. Returning fallback mock.',
-  })
-})
-
-app.put('/api/stages/:id', async (c) => {
-  const id = c.req.param('id')
-  const body = await c.req.json<{
-    title?: string
-    stage_data?: StageData
-    is_published?: boolean
-  }>()
-  const base = mockStages.find((stage) => stage.id === id) ?? mockStages[0]
-
-  const updated: StageRecord = {
-    ...base,
-    id,
-    title: body.title?.trim() || base.title,
-    stage_data: body.stage_data ?? base.stage_data,
-    is_published: body.is_published ?? base.is_published,
-    updated_at: mockNow,
-  }
-
-  return c.json({
-    data: updated,
-    message: 'Mock stage updated.',
-  })
-})
-
-app.delete('/api/stages/:id', (c) => {
-  const id = c.req.param('id')
-
-  return c.json({
-    data: {
-      id,
+      id: ownerResult.stage.id,
       deleted: true,
-      deleted_at: mockNow,
+      deleted_at: new Date().toISOString(),
     },
-    message: 'Mock stage deleted.',
+    message: 'Stage deleted.',
   })
 })
 
-app.post('/api/stages/:id/play_logs', async (c) => {
-  const stageId = c.req.param('id')
-  const body = await c.req.json<{
-    is_cleared?: boolean
-    retry_count?: number
-    player_id?: string | null
-  }>()
+app.post('/api/stages/:id/play_logs', optionalAuth, async (c) => {
+  const stageIdResult = parseStageId(c)
+  if (stageIdResult instanceof Response) {
+    return stageIdResult
+  }
+  const stageId = stageIdResult
+
+  const bodyResult = await readJsonObject(c)
+  if (bodyResult instanceof Response) {
+    return bodyResult
+  }
+
+  if (hasOwn(bodyResult, 'is_cleared') && typeof bodyResult.is_cleared !== 'boolean') {
+    return jsonError(c, 400, 'is_cleared はbooleanで指定してください。')
+  }
+  if (
+    hasOwn(bodyResult, 'retry_count') &&
+    (typeof bodyResult.retry_count !== 'number' ||
+      !Number.isInteger(bodyResult.retry_count) ||
+      bodyResult.retry_count < 0)
+  ) {
+    return jsonError(c, 400, 'retry_count は0以上の整数で指定してください。')
+  }
+
+  const isCleared = bodyResult.is_cleared === true
+  const retryCount = typeof bodyResult.retry_count === 'number' ? bodyResult.retry_count : 0
+  const authUserId = getAuthUserId(c)
+
+  const { data: stage, error: stageError } = await supabase
+    .from('stages')
+    .select('id,play_count,clear_count')
+    .eq('id', stageId)
+    .maybeSingle()
+
+  if (stageError) {
+    return dbError(c, stageError, '対象ステージの取得に失敗しました')
+  }
+  if (!stage) {
+    return jsonError(c, 404, '対象ステージが存在しません。')
+  }
+
+  const { data: playLog, error: logError } = await supabase
+    .from('play_logs')
+    .insert({
+      stage_id: stageId,
+      player_id: authUserId,
+      is_cleared: isCleared,
+      retry_count: retryCount,
+    })
+    .select('*')
+    .single()
+
+  if (logError) {
+    return dbError(c, logError, 'プレイログ記録に失敗しました')
+  }
+
+  const nextPlayCount = stage.play_count + 1
+  const nextClearCount = stage.clear_count + (isCleared ? 1 : 0)
+  const { data: updatedStage, error: updateError } = await supabase
+    .from('stages')
+    .update({
+      play_count: nextPlayCount,
+      clear_count: nextClearCount,
+    })
+    .eq('id', stageId)
+    .select('play_count,clear_count')
+    .single()
+
+  if (updateError) {
+    return dbError(c, updateError, 'ステージ統計更新に失敗しました')
+  }
 
   return c.json({
-    data: {
-      id: createMockId('playlog'),
-      stage_id: stageId,
-      player_id: body.player_id ?? null,
-      is_cleared: body.is_cleared ?? false,
-      retry_count: body.retry_count ?? 0,
-      created_at: mockNow,
-    },
+    data: playLog,
     aggregates: {
-      play_count: 1,
-      clear_count: body.is_cleared ? 1 : 0,
+      play_count: updatedStage.play_count,
+      clear_count: updatedStage.clear_count,
     },
   })
 })
 
-app.post('/api/stages/:id/likes', (c) => {
-  const stageId = c.req.param('id')
-  const stage = mockStages.find((item) => item.id === stageId) ?? mockStages[0]
-  const liked = (stage.like_count + stageId.length) % 2 === 0
+app.post('/api/stages/:id/likes', requireAuth, async (c) => {
+  const userId = getAuthUserId(c)
+  if (!userId) {
+    return jsonError(c, 401, '認証情報の取得に失敗しました。')
+  }
+
+  const stageIdResult = parseStageId(c)
+  if (stageIdResult instanceof Response) {
+    return stageIdResult
+  }
+  const stageId = stageIdResult
+
+  const { data: stage, error: stageError } = await supabase
+    .from('stages')
+    .select('id')
+    .eq('id', stageId)
+    .maybeSingle()
+  if (stageError) {
+    return dbError(c, stageError, '対象ステージの取得に失敗しました')
+  }
+  if (!stage) {
+    return jsonError(c, 404, '対象ステージが存在しません。')
+  }
+
+  const { data: existingLike, error: existingLikeError } = await supabase
+    .from('likes')
+    .select('stage_id')
+    .eq('stage_id', stageId)
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (existingLikeError) {
+    return dbError(c, existingLikeError, 'いいね状態の確認に失敗しました')
+  }
+
+  let liked: boolean
+  if (existingLike) {
+    liked = false
+    const { error: deleteLikeError } = await supabase
+      .from('likes')
+      .delete()
+      .eq('stage_id', stageId)
+      .eq('user_id', userId)
+    if (deleteLikeError) {
+      return dbError(c, deleteLikeError, 'いいね解除に失敗しました')
+    }
+  } else {
+    liked = true
+    const { error: insertLikeError } = await supabase
+      .from('likes')
+      .insert({ stage_id: stageId, user_id: userId })
+    if (insertLikeError) {
+      return dbError(c, insertLikeError, 'いいね登録に失敗しました')
+    }
+  }
+
+  const { count: likeCount, error: countError } = await supabase
+    .from('likes')
+    .select('*', { count: 'exact', head: true })
+    .eq('stage_id', stageId)
+
+  if (countError) {
+    return dbError(c, countError, 'いいね件数の算出に失敗しました')
+  }
+
+  const { data: updatedStage, error: updateError } = await supabase
+    .from('stages')
+    .update({ like_count: likeCount ?? 0 })
+    .eq('id', stageId)
+    .select('updated_at')
+    .single()
+
+  if (updateError) {
+    return dbError(c, updateError, 'ステージのいいね件数更新に失敗しました')
+  }
 
   return c.json({
     data: {
       stage_id: stageId,
-      user_id: mockProfile.id,
+      user_id: userId,
       liked,
-      like_count: liked ? stage.like_count + 1 : Math.max(stage.like_count - 1, 0),
-      updated_at: mockNow,
+      like_count: likeCount ?? 0,
+      updated_at: updatedStage.updated_at,
     },
   })
 })
+
+app.onError((error, c) => jsonError(c, 500, `サーバーエラー: ${error.message}`))
 
 export default app

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -665,24 +665,12 @@ app.post('/api/stages/:id/likes', requireAuth, async (c) => {
     }
   }
 
-  const { count: likeCount, error: countError } = await supabase
-    .from('likes')
-    .select('*', { count: 'exact', head: true })
-    .eq('stage_id', stageId)
-
-  if (countError) {
-    return dbError(c, countError, 'いいね件数の算出に失敗しました')
-  }
-
-  const { data: updatedStage, error: updateError } = await supabase
-    .from('stages')
-    .update({ like_count: likeCount ?? 0 })
-    .eq('id', stageId)
-    .select('updated_at')
+  const { data: updatedStage, error: recalcError } = await supabase
+    .rpc('recalc_stage_like_count', { stage_id: stageId })
     .single()
 
-  if (updateError) {
-    return dbError(c, updateError, 'ステージのいいね件数更新に失敗しました')
+  if (recalcError) {
+    return dbError(c, recalcError, 'ステージのいいね件数更新に失敗しました')
   }
 
   return c.json({
@@ -690,7 +678,7 @@ app.post('/api/stages/:id/likes', requireAuth, async (c) => {
       stage_id: stageId,
       user_id: userId,
       liked,
-      like_count: likeCount ?? 0,
+      like_count: updatedStage.like_count,
       updated_at: updatedStage.updated_at,
     },
   })

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -588,17 +588,13 @@ app.post('/api/stages/:id/play_logs', optionalAuth, async (c) => {
     return dbError(c, logError, 'プレイログ記録に失敗しました')
   }
 
-  const nextPlayCount = stage.play_count + 1
-  const nextClearCount = stage.clear_count + (isCleared ? 1 : 0)
-  const { data: updatedStage, error: updateError } = await supabase
-    .from('stages')
-    .update({
-      play_count: nextPlayCount,
-      clear_count: nextClearCount,
-    })
-    .eq('id', stageId)
-    .select('play_count,clear_count')
-    .single()
+  const { data: updatedStage, error: updateError } = await supabase.rpc(
+    'increment_stage_counters',
+    {
+      p_stage_id: stageId,
+      p_clear_increment: isCleared ? 1 : 0,
+    },
+  )
 
   if (updateError) {
     return dbError(c, updateError, 'ステージ統計更新に失敗しました')

--- a/apps/backend/src/types/database.ts
+++ b/apps/backend/src/types/database.ts
@@ -1,0 +1,114 @@
+import type { StageData } from './stage.js'
+
+export interface Database {
+  public: {
+    Tables: {
+      likes: {
+        Row: {
+          created_at: string
+          stage_id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          stage_id: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          stage_id?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      play_logs: {
+        Row: {
+          created_at: string
+          id: string
+          is_cleared: boolean
+          player_id: string | null
+          retry_count: number
+          stage_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          is_cleared: boolean
+          player_id?: string | null
+          retry_count?: number
+          stage_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          is_cleared?: boolean
+          player_id?: string | null
+          retry_count?: number
+          stage_id?: string
+        }
+        Relationships: []
+      }
+      profiles: {
+        Row: {
+          created_at: string
+          display_name: string
+          id: string
+        }
+        Insert: {
+          created_at?: string
+          display_name: string
+          id: string
+        }
+        Update: {
+          created_at?: string
+          display_name?: string
+          id?: string
+        }
+        Relationships: []
+      }
+      stages: {
+        Row: {
+          author_id: string
+          clear_count: number
+          created_at: string
+          id: string
+          is_published: boolean
+          like_count: number
+          play_count: number
+          stage_data: StageData
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          author_id: string
+          clear_count?: number
+          created_at?: string
+          id?: string
+          is_published?: boolean
+          like_count?: number
+          play_count?: number
+          stage_data: StageData
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          author_id?: string
+          clear_count?: number
+          created_at?: string
+          id?: string
+          is_published?: boolean
+          like_count?: number
+          play_count?: number
+          stage_data?: StageData
+          title?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: Record<string, never>
+    Functions: Record<string, never>
+    Enums: Record<string, never>
+    CompositeTypes: Record<string, never>
+  }
+}

--- a/apps/backend/src/types/stage.ts
+++ b/apps/backend/src/types/stage.ts
@@ -4,3 +4,5 @@ export type {
   StageGimmickKind,
   StageSchemaVersion,
 } from '@shared/types'
+
+export { createEmptyStageData, isStageData } from '@shared/types'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,15 @@ importers:
 
   apps/backend:
     dependencies:
+      '@supabase/supabase-js':
+        specifier: ^2.99.2
+        version: 2.99.2
       hono:
         specifier: ^4.12.8
         version: 4.12.8
+      jose:
+        specifier: ^6.2.1
+        version: 6.2.1
     devDependencies:
       '@types/node':
         specifier: ^25.5.0
@@ -491,6 +497,30 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.9':
     resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
 
+  '@supabase/auth-js@2.99.2':
+    resolution: {integrity: sha512-uRGNXMKEw4VhwouNW7N0XDAGqJP9redHNDmWi17dTrcO1lvFfyRiXsqqfgnVC8aqtRn8kLkLPEzHjiRWsni+oQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.99.2':
+    resolution: {integrity: sha512-xuXQARvjdfB1UPK1yUceZ5EGjOLkVz4rBAaloS9foXiAuseWEdgWBCxkIAFRxGBLGX8Uzo8kseq90jhPb+07Vg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/postgrest-js@2.99.2':
+    resolution: {integrity: sha512-ueiOVkbkTQ7RskwVmjR8zxWYw3VKOMxo1+qep+Dx/SgApqyhWBGd92waQb45tbLc7ydB5x8El8utXOLQTuTojQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.99.2':
+    resolution: {integrity: sha512-J6Jm9601dkpZf3+EJ48ki2pM4sFtCNm/BI0l8iEnrczgg+JSEQkMoOW5VSpM54t0pNs69bsz5PTmYJahDZKiIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.99.2':
+    resolution: {integrity: sha512-V/FF8kX8JGSefsVCG1spCLSrHdNR/JFeUMn1jS9KG/Eizjx+evtdKQKLJXFgIylY/bKTXKhc2SYDPIGrIhzsug==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.99.2':
+    resolution: {integrity: sha512-179rn5wq0wBAqqGwAwR7TUGg2NOaP+fkd5FCVbYJXby85fsRNPFoNJN8YRBepqX2tN7JJcnTjqaAMXuNjiyisA==}
+    engines: {node: '>=20.0.0'}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -509,6 +539,9 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
+  '@types/phoenix@1.6.7':
+    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -522,6 +555,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.57.0':
     resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
@@ -787,6 +823,10 @@ packages:
     resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
     engines: {node: '>=16.9.0'}
 
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -809,6 +849,9 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.1:
+    resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1115,6 +1158,18 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1454,6 +1509,44 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.9': {}
 
+  '@supabase/auth-js@2.99.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.99.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/postgrest-js@2.99.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.99.2':
+    dependencies:
+      '@types/phoenix': 1.6.7
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.99.2':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.99.2':
+    dependencies:
+      '@supabase/auth-js': 2.99.2
+      '@supabase/functions-js': 2.99.2
+      '@supabase/postgrest-js': 2.99.2
+      '@supabase/realtime-js': 2.99.2
+      '@supabase/storage-js': 2.99.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -1470,6 +1563,8 @@ snapshots:
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/phoenix@1.6.7': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -1489,6 +1584,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.5.0
 
   '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@10.0.3)(typescript@5.9.3))(eslint@10.0.3)(typescript@5.9.3)':
     dependencies:
@@ -1798,6 +1897,8 @@ snapshots:
 
   hono@4.12.8: {}
 
+  iceberg-js@0.8.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -1811,6 +1912,8 @@ snapshots:
       is-extglob: 2.1.1
 
   isexe@2.0.0: {}
+
+  jose@6.2.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -1990,8 +2093,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:
@@ -2048,6 +2150,8 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  ws@8.19.0: {}
 
   yallist@3.1.1: {}
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -36,7 +36,6 @@ enabled = true
 port = 54324
 smtp_port = 54325
 pop3_port = 54326
-admin_port = 54327
 
 [storage]
 enabled = true

--- a/supabase/migrations/20260317042000_issue12_schema.sql
+++ b/supabase/migrations/20260317042000_issue12_schema.sql
@@ -1,0 +1,63 @@
+begin;
+
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.profiles (
+  id uuid primary key references auth.users (id) on delete cascade,
+  display_name text not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.stages (
+  id uuid primary key default uuid_generate_v4(),
+  author_id uuid not null references public.profiles (id) on delete cascade,
+  title text not null,
+  stage_data jsonb not null,
+  is_published boolean not null default false,
+  play_count integer not null default 0 check (play_count >= 0),
+  clear_count integer not null default 0 check (clear_count >= 0),
+  like_count integer not null default 0 check (like_count >= 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.play_logs (
+  id uuid primary key default uuid_generate_v4(),
+  stage_id uuid not null references public.stages (id) on delete cascade,
+  player_id uuid references public.profiles (id) on delete cascade,
+  is_cleared boolean not null,
+  retry_count integer not null default 0 check (retry_count >= 0),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.likes (
+  stage_id uuid not null references public.stages (id) on delete cascade,
+  user_id uuid not null references public.profiles (id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (stage_id, user_id)
+);
+
+create index if not exists idx_stages_author_id on public.stages (author_id);
+create index if not exists idx_stages_is_published on public.stages (is_published);
+create index if not exists idx_stages_updated_at on public.stages (updated_at desc);
+create index if not exists idx_play_logs_stage_id on public.play_logs (stage_id);
+create index if not exists idx_play_logs_player_id on public.play_logs (player_id);
+create index if not exists idx_likes_user_id on public.likes (user_id);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_stages_updated_at on public.stages;
+create trigger set_stages_updated_at
+before update on public.stages
+for each row
+execute procedure public.set_updated_at();
+
+commit;

--- a/supabase/migrations/20260317042100_issue13_profile_trigger.sql
+++ b/supabase/migrations/20260317042100_issue13_profile_trigger.sql
@@ -1,0 +1,31 @@
+begin;
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  initial_display_name text;
+begin
+  initial_display_name := nullif(trim(new.raw_user_meta_data->>'name'), '');
+
+  insert into public.profiles (id, display_name)
+  values (
+    new.id,
+    coalesce(initial_display_name, 'user-' || substring(new.id::text from 1 for 8))
+  )
+  on conflict (id) do nothing;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+after insert on auth.users
+for each row
+execute procedure public.handle_new_user();
+
+commit;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,20 +1,5 @@
 begin;
 
-create table if not exists public.dev_seed_log (
-  key text primary key,
-  value text not null,
-  updated_at timestamptz not null default now()
-);
-
-insert into public.dev_seed_log (key, value)
-values
-  ('seed_version', '2026-03-16'),
-  ('seed_note', 'profiles/stages テーブル作成後に開発用データを追加')
-on conflict (key)
-do update set
-  value = excluded.value,
-  updated_at = now();
-
 do $$
 begin
   if to_regclass('public.profiles') is not null then


### PR DESCRIPTION
## 📝 背景・目的
<!-- なぜこの変更が必要なのか、何を解決するのかを簡潔に記述してください -->
Epic #28 の完了に向けて、#12 #13 #14 の実装を統合しました。
<!-- 関連するIssueがある場合は、 `Close #123` のようにIssue番号を記載してください（マージ時に自動でIssueが閉じられます） -->
Close #12
Close #13
Close #14
Close #28

## 🛠 変更内容
<!-- このPRで具体的にどのような実装・修正を行ったかを箇条書きで記述してください -->
- `supabase/migrations` に `profiles/stages/play_logs/likes`のスキーマを追加
- `auth.users` 作成時に `profiles` を自動生成する関数・トリガーを追加  
- Hono に JWT 検証（`Authorization: Bearer<token>`）ミドルウェアを実装
- `profiles/stages` CRUD、ステージ所有者認可、`play_logs`記録＋統計更新、`likes` トグル/取得を実装

## ✅ 動作確認・テスト
<!-- どのような動作確認を行ったか、またはレビュアーにどう確認してほしいかを記述してください -->
- `pnpm --filter frontend lint`
   - `pnpm --filter hono exec -- tsc --noEmit`
   - `pnpm --filter frontend build`
<!-- UIの変更を伴う場合は、ここにスクリーンショットやGIF動画を貼ると非常に分かりやすいです -->
- [ ] 

## 🔍 レビューポイント（該当する場合）
<!-- 「ここの設計で迷った」「この処理のパフォーマンスが気になる」など、特に見てほしいポイントがあれば記述してください -->
- 401/403/404 の返却条件が設計どおりか
- 所有者チェック、`play_count/clear_count/like_count` 更新の整合性     

## 📋 チェックリスト
<!-- PRを提出する前に以下の項目を確認し、[x] を入れてください -->
- [x] ビルド・型チェック通過
- [x] 設計ドキュメント準拠
- [x] デバッグコードなし