### PR TITLE
feat: ステージ共有リンク機能と結果画面強化

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -70,11 +70,48 @@ const getQueryParam = (search: string, key: string): string | null => {
   return null
 }
 
-const parseResultQuery = (search: string): { stageId?: string; cleared: boolean } => {
+const parseNonNegativeInt = (rawValue: string | null): number | undefined => {
+  if (!rawValue) {
+    return undefined
+  }
+  const value = Number.parseInt(rawValue, 10)
+  if (!Number.isFinite(value) || value < 0) {
+    return undefined
+  }
+  return value
+}
+
+type ResultQuery = {
+  stageId?: string
+  cleared: boolean
+  logStatus?: 'success' | 'failed'
+  playLogId?: string
+  playCount?: number
+  clearCount?: number
+  logError?: string
+}
+
+const parseResultQuery = (search: string): ResultQuery => {
   const stageIdRaw = getQueryParam(search, 'stageId')
   const stageId = stageIdRaw && UUID_PATTERN.test(stageIdRaw) ? stageIdRaw : undefined
   const cleared = getQueryParam(search, 'cleared') === 'true'
-  return { stageId, cleared }
+  const logStatusRaw = getQueryParam(search, 'logStatus')
+  const logStatus =
+    logStatusRaw === 'success' || logStatusRaw === 'failed' ? logStatusRaw : undefined
+  const playLogId = getQueryParam(search, 'playLogId') ?? undefined
+  const playCount = parseNonNegativeInt(getQueryParam(search, 'playCount'))
+  const clearCount = parseNonNegativeInt(getQueryParam(search, 'clearCount'))
+  const logError = getQueryParam(search, 'logError') ?? undefined
+
+  return {
+    stageId,
+    cleared,
+    logStatus,
+    playLogId,
+    playCount,
+    clearCount,
+    logError,
+  }
 }
 
 const isRouteActive = (currentPathname: string, path: string): boolean => {
@@ -269,6 +306,11 @@ function App() {
         <ResultPage
           stageId={resultQuery.stageId}
           cleared={resultQuery.cleared}
+          logStatus={resultQuery.logStatus}
+          playLogId={resultQuery.playLogId}
+          playCount={resultQuery.playCount}
+          clearCount={resultQuery.clearCount}
+          logError={resultQuery.logError}
         />
       )
     }

--- a/apps/frontend/src/pages/DashboardPage.tsx
+++ b/apps/frontend/src/pages/DashboardPage.tsx
@@ -8,15 +8,16 @@ import { SpellCheck } from 'lucide-react'
 import type {
   Pagination,
   ProfileResponse,
+  StageDeleteResponse,
   StageListItemDto,
   StageListResponse,
 } from '../types/api'
-import { apiGet } from '../utils/api'
+import { apiDelete, apiGet } from '../utils/api'
+import { copyStagePlayUrl } from '../utils/stageShare'
 import './DashboardPage.css'
 
 type DashboardStage = StageListItemDto & {
   imageUrl?: string
-  isMock?: boolean
 }
 
 const initialPagination: Pagination = {
@@ -29,74 +30,22 @@ const initialPagination: Pagination = {
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : '不明なエラーが発生しました。'
 
-const mockStages: DashboardStage[] = [
-  {
-    id: '1',
-    author_id: 'mock-user-1',
-    title: '仮のステージ 1',
-    is_published: true,
-    play_count: 0,
-    clear_count: 0,
-    like_count: 8,
-    created_at: new Date(Date.now() - 1000 * 60 * 60 * 24 * 4).toISOString(),
-    updated_at: new Date().toISOString(),
-    isMock: true,
-  },
-  {
-    id: '2',
-    author_id: 'mock-user-1',
-    title: '仮のステージ 2',
-    is_published: false,
-    play_count: 0,
-    clear_count: 0,
-    like_count: 2,
-    created_at: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(),
-    updated_at: new Date().toISOString(),
-    isMock: true,
-  },
-  {
-    id: '3',
-    author_id: 'mock-user-1',
-    title: '仮のステージ 3',
-    is_published: true,
-    play_count: 0,
-    clear_count: 0,
-    like_count: 15,
-    created_at: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2).toISOString(),
-    updated_at: new Date().toISOString(),
-    isMock: true,
-  },
-  {
-    id: '4',
-    author_id: 'mock-user-1',
-    title: '仮のステージ 4',
-    is_published: false,
-    play_count: 0,
-    clear_count: 0,
-    like_count: 5,
-    created_at: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
-    updated_at: new Date().toISOString(),
-    isMock: true,
-  },
-]
-
 type StageSortKey = 'favorite' | 'created' | 'name'
 type SortOrder = 'desc' | 'asc'
 
 export const DashboardPage = () => {
   const [displayName, setDisplayName] = useState('未取得')
-  const [stages, setStages] = useState<DashboardStage[]>(mockStages) // 仮データを初期値に設定
-  const [pagination, setPagination] = useState<Pagination>({
-    ...initialPagination,
-    total: mockStages.length,
-    total_pages: 1,
-  })
+  const [stages, setStages] = useState<DashboardStage[]>([])
+  const [pagination, setPagination] = useState<Pagination>(initialPagination)
   const [sortKey, setSortKey] = useState<StageSortKey>('created')
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc')
   const [searchKeyword, setSearchKeyword] = useState('')
   const [favoriteStageIds, setFavoriteStageIds] = useState<Set<string>>(new Set())
   const [isLoading, setIsLoading] = useState(true)
+  const [isDeletingStageId, setIsDeletingStageId] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [shareMessage, setShareMessage] = useState<string | null>(null)
+  const [shareErrorMessage, setShareErrorMessage] = useState<string | null>(null)
 
   const filteredStages = stages.filter((stage) =>
     stage.title.toLowerCase().includes(searchKeyword.trim().toLowerCase())
@@ -133,13 +82,35 @@ export const DashboardPage = () => {
     })
   }
 
-  const handleDeleteStage = (stageId: string) => {
-    if (confirm('このステージを削除してもよろしいですか？')) {
+  const handleDeleteStage = async (stageId: string) => {
+    if (!window.confirm('このステージを削除してもよろしいですか？')) {
+      return
+    }
+
+    try {
+      setIsDeletingStageId(stageId)
+      setErrorMessage(null)
+      await apiDelete<StageDeleteResponse>(`/api/stages/${stageId}`, { withAuth: true })
       setStages((prevStages) => prevStages.filter((stage) => stage.id !== stageId))
       setPagination((prevPagination) => ({
         ...prevPagination,
-        total: prevPagination.total - 1,
+        total: Math.max(prevPagination.total - 1, 0),
       }))
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error))
+    } finally {
+      setIsDeletingStageId(null)
+    }
+  }
+
+  const handleCopyShareLink = async (stage: DashboardStage) => {
+    try {
+      const stageUrl = await copyStagePlayUrl(stage.id)
+      setShareMessage(`「${stage.title}」の共有リンクをコピーしました: ${stageUrl}`)
+      setShareErrorMessage(null)
+    } catch (error) {
+      setShareErrorMessage(getErrorMessage(error))
+      setShareMessage(null)
     }
   }
 
@@ -183,20 +154,15 @@ export const DashboardPage = () => {
           withAuth: true,
         })
 
-        setStages(stageResponse.data.map((stage) => ({ ...stage, isMock: false })))
+        setStages(stageResponse.data)
         setPagination(stageResponse.pagination)
       } catch (error) {
         if (error instanceof DOMException && error.name === 'AbortError') {
           return
         }
         setErrorMessage(getErrorMessage(error))
-        // エラー時に仮データを使用
-        setStages(mockStages)
-        setPagination({
-          ...initialPagination,
-          total: mockStages.length,
-          total_pages: 1,
-        })
+        setStages([])
+        setPagination(initialPagination)
       } finally {
         setIsLoading(false)
       }
@@ -217,11 +183,17 @@ export const DashboardPage = () => {
       {isLoading && <p className="status-text">読み込み中...</p>}
       {errorMessage && (
         <p className="error-text" role="alert">
-          読み込み失敗: {errorMessage}
+          処理失敗: {errorMessage}
+        </p>
+      )}
+      {shareMessage && <p className="success-text">{shareMessage}</p>}
+      {shareErrorMessage && (
+        <p className="error-text" role="alert">
+          共有リンクのコピー失敗: {shareErrorMessage}
         </p>
       )}
 
-      {!isLoading && !errorMessage && (
+      {!isLoading && (
         <>
           <div className="dashboard-toolbar">
             <div className="dashboard-toolbar-left">
@@ -284,10 +256,7 @@ export const DashboardPage = () => {
           {sortedStages.length === 0 && <p className="status-text">作成したステージはまだありません。</p>}
           <ul className="stage-list">
             {sortedStages.map((stage) => (
-              <li
-                key={stage.id}
-                className={`stage-item ${stage.isMock ? 'stage-item-mock' : ''}`.trim()}
-              >
+              <li key={stage.id} className="stage-item">
                 <div className="stage-card">
                   <div className="stage-image-area">
                     {stage.imageUrl ? (
@@ -372,11 +341,26 @@ export const DashboardPage = () => {
                     テストプレイ
                   </AppLink>
                   <button
-                    onClick={() => handleDeleteStage(stage.id)}
+                    type="button"
+                    className="button secondary"
+                    onClick={() => {
+                      void handleCopyShareLink(stage)
+                    }}
+                  >
+                    共有リンク
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void handleDeleteStage(stage.id)
+                    }}
                     className="button secondary stage-delete-button action-with-label"
+                    disabled={isDeletingStageId === stage.id}
                   >
                     <Trash2 />
-                    <span className="action-label">消去</span>
+                    <span className="action-label">
+                      {isDeletingStageId === stage.id ? '削除中' : '消去'}
+                    </span>
                   </button>
                 </div>
               </li>

--- a/apps/frontend/src/pages/HomePage.tsx
+++ b/apps/frontend/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { AppLink } from '../components/AppLink'
 import type { Pagination, StageListItemDto, StageListResponse } from '../types/api'
 import { apiGet } from '../utils/api'
+import { copyStagePlayUrl } from '../utils/stageShare'
 import '../styles/HomePage.css'
 
 const initialPagination: Pagination = {
@@ -19,6 +20,8 @@ export const HomePage = () => {
   const [pagination, setPagination] = useState<Pagination>(initialPagination)
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [shareMessage, setShareMessage] = useState<string | null>(null)
+  const [shareErrorMessage, setShareErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
     const controller = new AbortController()
@@ -53,6 +56,17 @@ export const HomePage = () => {
 
     return () => controller.abort()
   }, [])
+
+  const handleCopyShareLink = async (stage: StageListItemDto) => {
+    try {
+      const stageUrl = await copyStagePlayUrl(stage.id)
+      setShareMessage(`「${stage.title}」の共有リンクをコピーしました: ${stageUrl}`)
+      setShareErrorMessage(null)
+    } catch (error) {
+      setShareErrorMessage(getErrorMessage(error))
+      setShareMessage(null)
+    }
+  }
 
   return (
     <>
@@ -97,6 +111,12 @@ export const HomePage = () => {
             読み込み失敗: {errorMessage}
           </p>
         )}
+        {shareMessage && <p className="success-text">{shareMessage}</p>}
+        {shareErrorMessage && (
+          <p className="error-text" role="alert">
+            共有リンクのコピー失敗: {shareErrorMessage}
+          </p>
+        )}
 
         {!isLoading && !errorMessage && (
           <>
@@ -114,9 +134,20 @@ export const HomePage = () => {
                       {stage.like_count}
                     </p>
                   </div>
-                  <AppLink to={`/play/${stage.id}`} className="button secondary">
-                    プレイ
-                  </AppLink>
+                  <div className="inline-actions">
+                    <AppLink to={`/play/${stage.id}`} className="button secondary">
+                      プレイ
+                    </AppLink>
+                    <button
+                      type="button"
+                      className="button secondary"
+                      onClick={() => {
+                        void handleCopyShareLink(stage)
+                      }}
+                    >
+                      共有リンクをコピー
+                    </button>
+                  </div>
                 </li>
               ))}
               {stages.length === 0 && <li className="status-text">公開ステージは0件です。</li>}

--- a/apps/frontend/src/pages/PlayPage.tsx
+++ b/apps/frontend/src/pages/PlayPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { AppLink } from '../components/AppLink'
 import { useKAPLAY } from '../features/game/useKAPLAY'
 import type {
   LikeToggleResponse,
@@ -30,6 +29,25 @@ export const PlayPage = ({ stageId }: PlayPageProps) => {
   const [likeMessage, setLikeMessage] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const finishingRef = useRef(false)
+  const isMountedRef = useRef(false)
+  const finishAbortControllerRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    isMountedRef.current = true
+
+    return () => {
+      isMountedRef.current = false
+      finishAbortControllerRef.current?.abort()
+      finishAbortControllerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    finishingRef.current = false
+    setIsFinishingPlay(false)
+    finishAbortControllerRef.current?.abort()
+    finishAbortControllerRef.current = null
+  }, [stageId])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -84,6 +102,10 @@ export const PlayPage = ({ stageId }: PlayPageProps) => {
       return
     }
 
+    const finishController = new AbortController()
+    finishAbortControllerRef.current?.abort()
+    finishAbortControllerRef.current = finishController
+
     finishingRef.current = true
     setIsFinishingPlay(true)
     setErrorMessage(null)
@@ -92,7 +114,12 @@ export const PlayPage = ({ stageId }: PlayPageProps) => {
       const response = await apiPost<PlayLogResponse>(
         `/api/stages/${stageId}/play_logs`,
         { is_cleared: cleared },
+        { signal: finishController.signal },
       )
+
+      if (finishController.signal.aborted || !isMountedRef.current) {
+        return
+      }
 
       navigate(
         buildResultPath({
@@ -105,6 +132,14 @@ export const PlayPage = ({ stageId }: PlayPageProps) => {
         }),
       )
     } catch (error) {
+      if (
+        finishController.signal.aborted ||
+        (error instanceof DOMException && error.name === 'AbortError') ||
+        !isMountedRef.current
+      ) {
+        return
+      }
+
       navigate(
         buildResultPath({
           stageId,
@@ -113,6 +148,14 @@ export const PlayPage = ({ stageId }: PlayPageProps) => {
           logError: getErrorMessage(error),
         }),
       )
+    } finally {
+      if (finishAbortControllerRef.current === finishController) {
+        finishAbortControllerRef.current = null
+      }
+      if (isMountedRef.current) {
+        finishingRef.current = false
+        setIsFinishingPlay(false)
+      }
     }
   }, [stageId])
 
@@ -181,12 +224,22 @@ export const PlayPage = ({ stageId }: PlayPageProps) => {
           </div>
 
           <div className="inline-actions">
-            <AppLink to={`/edit/${stageId}`} className="button secondary">
+            <button
+              type="button"
+              className="button secondary"
+              onClick={() => navigate(`/edit/${stageId}`)}
+              disabled={isFinishingPlay}
+            >
               編集へ
-            </AppLink>
-            <AppLink to="/" className="button secondary">
+            </button>
+            <button
+              type="button"
+              className="button secondary"
+              onClick={() => navigate('/')}
+              disabled={isFinishingPlay}
+            >
               ホームへ
-            </AppLink>
+            </button>
           </div>
         </>
       )}

--- a/apps/frontend/src/pages/PlayPage.tsx
+++ b/apps/frontend/src/pages/PlayPage.tsx
@@ -3,6 +3,7 @@ import { AppLink } from '../components/AppLink'
 import { useKAPLAY } from '../features/game/useKAPLAY'
 import type {
   LikeToggleResponse,
+  PlayLogResponse,
   StageDto,
   StageResponse,
 } from '../types/api'
@@ -16,10 +17,16 @@ interface PlayPageProps {
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : '不明なエラーが発生しました。'
 
+const buildResultPath = (params: Record<string, string>): string => {
+  const searchParams = new URLSearchParams(params)
+  return `/result?${searchParams.toString()}`
+}
+
 export const PlayPage = ({ stageId }: PlayPageProps) => {
   const [stage, setStage] = useState<StageDto | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isTogglingLike, setIsTogglingLike] = useState(false)
+  const [isFinishingPlay, setIsFinishingPlay] = useState(false)
   const [likeMessage, setLikeMessage] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const finishingRef = useRef(false)
@@ -72,16 +79,41 @@ export const PlayPage = ({ stageId }: PlayPageProps) => {
     }
   }
 
-  const handleFinishPlay = useCallback((cleared: boolean) => {
+  const handleFinishPlay = useCallback(async (cleared: boolean) => {
     if (finishingRef.current) {
       return
     }
+
     finishingRef.current = true
-    navigate(`/result?stageId=${encodeURIComponent(stageId)}&cleared=${String(cleared)}`)
-    // 結果遷移を優先し、ログはバックグラウンド送信する
-    void apiPost(`/api/stages/${stageId}/play_logs`, { is_cleared: cleared }).catch(() => {
-      // ログ送信失敗はゲーム体験に影響させない
-    })
+    setIsFinishingPlay(true)
+    setErrorMessage(null)
+
+    try {
+      const response = await apiPost<PlayLogResponse>(
+        `/api/stages/${stageId}/play_logs`,
+        { is_cleared: cleared },
+      )
+
+      navigate(
+        buildResultPath({
+          stageId,
+          cleared: String(cleared),
+          logStatus: 'success',
+          playLogId: response.data.id,
+          playCount: String(response.aggregates.play_count),
+          clearCount: String(response.aggregates.clear_count),
+        }),
+      )
+    } catch (error) {
+      navigate(
+        buildResultPath({
+          stageId,
+          cleared: String(cleared),
+          logStatus: 'failed',
+          logError: getErrorMessage(error),
+        }),
+      )
+    }
   }, [stageId])
 
   const { canvasRef } = useKAPLAY({
@@ -94,7 +126,8 @@ export const PlayPage = ({ stageId }: PlayPageProps) => {
     <section className="page-card">
       <h1 className="page-heading">プレイ画面</h1>
       <p className="status-text">
-        API: <code>GET /api/stages/:id</code> / <code>POST /api/stages/:id/likes</code>
+        API: <code>GET /api/stages/:id</code> / <code>POST /api/stages/:id/likes</code> /{' '}
+        <code>POST /api/stages/:id/play_logs</code>
       </p>
 
       {isLoading && <p className="status-text">ステージ読込中...</p>}
@@ -110,6 +143,7 @@ export const PlayPage = ({ stageId }: PlayPageProps) => {
             キャンバスの初期化済み（<code>useKAPLAY</code>）。デモ用に C キーでクリア、
             F キーで失敗を発火できます。
           </p>
+          {isFinishingPlay && <p className="status-text">プレイログを送信して結果画面へ移動中です...</p>}
 
           <div className="canvas-wrapper">
             <canvas ref={canvasRef} width={960} height={540} className="game-canvas" style={{ touchAction: 'none' }} />
@@ -120,17 +154,27 @@ export const PlayPage = ({ stageId }: PlayPageProps) => {
               type="button"
               className="button secondary"
               onClick={handleLikeToggle}
-              disabled={isTogglingLike}
+              disabled={isTogglingLike || isFinishingPlay}
             >
               {isTogglingLike ? '送信中...' : 'いいねトグル'}
             </button>
-            <button type="button" className="button" onClick={() => handleFinishPlay(true)}>
+            <button
+              type="button"
+              className="button"
+              onClick={() => {
+                void handleFinishPlay(true)
+              }}
+              disabled={isFinishingPlay}
+            >
               クリアして結果へ
             </button>
             <button
               type="button"
               className="button secondary"
-              onClick={() => handleFinishPlay(false)}
+              onClick={() => {
+                void handleFinishPlay(false)
+              }}
+              disabled={isFinishingPlay}
             >
               失敗して結果へ
             </button>

--- a/apps/frontend/src/pages/ResultPage.tsx
+++ b/apps/frontend/src/pages/ResultPage.tsx
@@ -1,54 +1,112 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { AppLink } from '../components/AppLink'
 import type { PlayLogResponse } from '../types/api'
 import { apiPost } from '../utils/api'
+import { copyStagePlayUrl } from '../utils/stageShare'
 
 interface ResultPageProps {
   stageId?: string
   cleared: boolean
+  logStatus?: 'success' | 'failed'
+  playLogId?: string
+  playCount?: number
+  clearCount?: number
+  logError?: string
 }
 
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : '不明なエラーが発生しました。'
 
-export const ResultPage = ({ stageId, cleared }: ResultPageProps) => {
+export const ResultPage = ({
+  stageId,
+  cleared,
+  logStatus,
+  playLogId,
+  playCount,
+  clearCount,
+  logError,
+}: ResultPageProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [resultMessage, setResultMessage] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [shareMessage, setShareMessage] = useState<string | null>(null)
+  const [shareErrorMessage, setShareErrorMessage] = useState<string | null>(null)
 
-  useEffect(() => {
+  const submitPlayLog = useCallback(async () => {
     if (!stageId) {
+      setResultMessage(null)
       setErrorMessage('stageId が未指定のため、プレイログを送信できません。')
       return
     }
 
-    const submitPlayLog = async () => {
-      try {
-        setIsSubmitting(true)
-        setErrorMessage(null)
-        setResultMessage(null)
+    try {
+      setIsSubmitting(true)
+      setErrorMessage(null)
+      setResultMessage(null)
 
-        const response = await apiPost<PlayLogResponse>(
-          `/api/stages/${stageId}/play_logs`,
-          {
-            is_cleared: cleared,
-            retry_count: 0,
-            player_id: null,
-          },
-        )
+      const response = await apiPost<PlayLogResponse>(
+        `/api/stages/${stageId}/play_logs`,
+        {
+          is_cleared: cleared,
+          retry_count: 0,
+        },
+      )
 
+      setResultMessage(
+        `ログ送信完了: ${response.data.id} / play_count: ${response.aggregates.play_count} / clear_count: ${response.aggregates.clear_count}`,
+      )
+    } catch (error) {
+      setResultMessage(null)
+      setErrorMessage(getErrorMessage(error))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [cleared, stageId])
+
+  useEffect(() => {
+    if (!stageId) {
+      setResultMessage(null)
+      setErrorMessage('stageId が未指定のため、プレイログを送信できません。')
+      return
+    }
+
+    if (logStatus === 'success') {
+      setErrorMessage(null)
+      if (playLogId) {
         setResultMessage(
-          `ログ送信完了: ${response.data.id} / clear_count加算: ${response.aggregates.clear_count}`,
+          `ログ送信完了: ${playLogId} / play_count: ${playCount ?? '-'} / clear_count: ${clearCount ?? '-'}`,
         )
-      } catch (error) {
-        setErrorMessage(getErrorMessage(error))
-      } finally {
-        setIsSubmitting(false)
+      } else {
+        setResultMessage('プレイログ送信に成功しました。')
       }
+      return
+    }
+
+    if (logStatus === 'failed') {
+      setResultMessage(null)
+      setErrorMessage(logError ?? 'プレイログ送信に失敗しました。')
+      return
     }
 
     void submitPlayLog()
-  }, [cleared, stageId])
+  }, [clearCount, logError, logStatus, playCount, playLogId, stageId, submitPlayLog])
+
+  const handleCopyShareLink = useCallback(async () => {
+    if (!stageId) {
+      setShareErrorMessage('stageId が未指定のため共有リンクを生成できません。')
+      setShareMessage(null)
+      return
+    }
+
+    try {
+      const stageUrl = await copyStagePlayUrl(stageId)
+      setShareMessage(`共有リンクをコピーしました: ${stageUrl}`)
+      setShareErrorMessage(null)
+    } catch (error) {
+      setShareErrorMessage(getErrorMessage(error))
+      setShareMessage(null)
+    }
+  }, [stageId])
 
   return (
     <section className="page-card">
@@ -65,12 +123,41 @@ export const ResultPage = ({ stageId, cleared }: ResultPageProps) => {
           ログ送信失敗: {errorMessage}
         </p>
       )}
+      {shareMessage && <p className="success-text">{shareMessage}</p>}
+      {shareErrorMessage && (
+        <p className="error-text" role="alert">
+          共有リンクのコピー失敗: {shareErrorMessage}
+        </p>
+      )}
 
       <div className="inline-actions">
+        {stageId && errorMessage && (
+          <button
+            type="button"
+            className="button secondary"
+            onClick={() => {
+              void submitPlayLog()
+            }}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? '再送信中...' : 'プレイログを再送信'}
+          </button>
+        )}
         {stageId && (
-          <AppLink to={`/play/${stageId}`} className="button">
-            もう一度プレイ
-          </AppLink>
+          <>
+            <button
+              type="button"
+              className="button secondary"
+              onClick={() => {
+                void handleCopyShareLink()
+              }}
+            >
+              共有リンクをコピー
+            </button>
+            <AppLink to={`/play/${stageId}`} className="button">
+              もう一度プレイ
+            </AppLink>
+          </>
         )}
         <AppLink to="/" className="button secondary">
           ホームへ戻る

--- a/apps/frontend/src/types/api.ts
+++ b/apps/frontend/src/types/api.ts
@@ -49,6 +49,12 @@ export type StageResponse = ApiEnvelope<StageDto>
 
 export type ProfileResponse = ApiEnvelope<ProfileDto>
 
+export type StageDeleteResponse = ApiEnvelope<{
+  id: string
+  deleted: boolean
+  deleted_at: string
+}>
+
 export interface ProfileLikesResponse extends ApiEnvelope<StageListItemDto[]> {
   total: number
 }

--- a/apps/frontend/src/utils/stageShare.ts
+++ b/apps/frontend/src/utils/stageShare.ts
@@ -1,0 +1,39 @@
+const copyTextWithExecCommand = (text: string): boolean => {
+  const textArea = document.createElement('textarea')
+  textArea.value = text
+  textArea.setAttribute('readonly', 'true')
+  textArea.style.position = 'fixed'
+  textArea.style.left = '-9999px'
+  textArea.style.top = '0'
+
+  document.body.appendChild(textArea)
+  textArea.focus()
+  textArea.select()
+
+  try {
+    return document.execCommand('copy')
+  } finally {
+    document.body.removeChild(textArea)
+  }
+}
+
+export const buildStagePlayPath = (stageId: string): string =>
+  `/play/${encodeURIComponent(stageId)}`
+
+export const buildStagePlayUrl = (stageId: string): string =>
+  `${window.location.origin}${buildStagePlayPath(stageId)}`
+
+export const copyStagePlayUrl = async (stageId: string): Promise<string> => {
+  const stageUrl = buildStagePlayUrl(stageId)
+
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(stageUrl)
+    return stageUrl
+  }
+
+  if (!copyTextWithExecCommand(stageUrl)) {
+    throw new Error('共有リンクのコピーに失敗しました。')
+  }
+
+  return stageUrl
+}


### PR DESCRIPTION
## 📝 背景・目的
<!-- なぜこの変更が必要なのか、何を解決するのかを簡潔に記述してください -->
#17（ダッシュボード・ステージ一覧・リザルトUI）と、#29（フロントUI/状態管理Epic）の未完了項目を完了させるため。
<!-- 関連するIssueがある場合は、 `Close #123` のようにIssue番号を記載してください（マージ時に自動でIssueが閉じられます） -->
Close #17 
Close #29

## 🛠 変更内容
<!-- このPRで具体的にどのような実装・修正を行ったかを箇条書きで記述してください -->
- ホーム・ダッシュボード・リザルトに「`/play/[id]` 共有リンクコピー」導線を追加
- `PlayPage -> ResultPage` の `play_logs` 連動フローを整理し、重複送信を防止
- リザルト画面でログ送信成功/失敗（ID・集計・エラー）を表示し、失敗時の再送信に対応
- ダッシュボードの仮データ依存を除去し、削除アクションを `DELETE /api/stages/:id` 連動化
- `App.tsx` で結果クエリ（`logStatus` など）を解釈する処理を追加
- `stageShare` ユーティリティと `StageDeleteResponse` 型を追加

## ✅ 動作確認・テスト
<!-- どのような動作確認を行ったか、またはレビュアーにどう確認してほしいかを記述してください -->
<!-- UIの変更を伴う場合は、ここにスクリーンショットやGIF動画を貼ると非常に分かりやすいです -->
- [x] ホームで公開ステージ一覧表示、プレイ導線、共有リンクコピーが動作すること
- [x] ダッシュボードで自作ステージ表示、削除、共有リンクコピーが動作すること
- [x] プレイ終了時に結果画面へ遷移し、ログ送信結果が表示されること（失敗時は再送信可能）
- [x] `pnpm --filter frontend lint`
- [x] `pnpm --filter frontend build`
- [x] `pnpm --filter hono typecheck`

## 🔍 レビューポイント（該当する場合）
<!-- 「ここの設計で迷った」「この処理のパフォーマンスが気になる」など、特に見てほしいポイントがあれば記述してください -->
- `PlayPage` でログ送信完了後に結果遷移する設計（体験/信頼性のトレードオフ）
- `ResultPage` のクエリ由来ステータス表示と再送信導線の妥当性
- ダッシュボード削除時のエラーハンドリングと空状態表示

## 📋 チェックリスト
<!-- PRを提出する前に以下の項目を確認し、[x] を入れてください -->
- [x] ビルドやテストが正常に通過すること
- [x] 必要なドキュメントの更新を行ったこと（該当する場合）
- [x] 不要なコメントやデバッグコードが残っていないこと