### PR TITLE
feat: 動的OGP生成とSNSクローラー対応を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET=<google_client_secret>
 
 - `publishable_key` / `secret_key` は `pnpm dlx supabase status` で確認できます。
 - `apps/backend/.env` は `apps/backend/.env.example` から作成できます。
+- 動的OGP（`/play/:id`）でステージ情報を埋め込む場合、フロントの実行環境（Vercel）へ `OGP_STAGE_API_BASE_URL`（例: `https://<backend-domain>`）を設定してください。
 
 ### 3. Supabase ローカル環境の起動
 
@@ -109,6 +110,24 @@ pnpm --filter frontend lint
 pnpm --filter frontend build
 pnpm --filter hono typecheck
 ```
+
+## 🔗 動的OGP（Issue #23）
+
+- `apps/frontend/api/ogp/[stageId].ts` が、ステージIDごとの `og:*` / `twitter:*` メタを返します（タイトル・説明・URL・画像）。
+- `apps/frontend/api/ogp-image/[stageId].ts` が、ステージID入りの動的OGP画像（SVG）を生成します。
+- `apps/frontend/vercel.json` で、SNSクローラー系 User-Agent の `/play/:stageId` リクエストを OGP関数へリライトします。
+
+確認例（ローカルVercel実行時）:
+
+```bash
+curl -A "Twitterbot" http://localhost:5173/play/<stage-id>
+curl http://localhost:5173/api/ogp-image/<stage-id>?title=test-stage
+```
+
+期待結果:
+
+- 1つ目のレスポンスHTMLに `og:title` / `twitter:title` / `og:image` が含まれること
+- 2つ目が `image/svg+xml` として返ること
 
 ## 🧪 CCSSトランスパイラPoC（独立CLI）
 

--- a/apps/frontend/api/ogp-image/[stageId].ts
+++ b/apps/frontend/api/ogp-image/[stageId].ts
@@ -1,0 +1,80 @@
+const toSingleString = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') {
+    return value[0]
+  }
+  return null
+}
+
+const safeDecodeURIComponent = (value: string): string | null => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return null
+  }
+}
+
+const truncate = (value: string, maxLength: number): string =>
+  value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value
+
+const escapeXml = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+
+const normalizeTitle = (value: string): string =>
+  truncate(value.trim().length > 0 ? value.trim() : 'megalo2026 stage', 36)
+
+const normalizeStageId = (value: string): string =>
+  truncate(value.trim().length > 0 ? value.trim() : 'unknown-stage', 42)
+
+const buildSvg = (title: string, stageId: string): string => {
+  const escapedTitle = escapeXml(title)
+  const escapedStageId = escapeXml(stageId)
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="${escapedTitle}">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220" />
+      <stop offset="100%" stop-color="#1f5fae" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="44" y="44" width="1112" height="542" rx="24" fill="rgba(255,255,255,0.12)" stroke="rgba(255,255,255,0.28)" />
+  <text x="80" y="138" fill="#eaf3ff" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="40" font-weight="700">megalo2026</text>
+  <text x="80" y="250" fill="#ffffff" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="58" font-weight="800">${escapedTitle}</text>
+  <text x="80" y="334" fill="#d5e5ff" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="30" font-weight="500">Swipe the wind, clear the stage.</text>
+  <text x="80" y="520" fill="#9fc1ee" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="28">stage: ${escapedStageId}</text>
+</svg>`
+}
+
+export default function handler(
+  req: { query: Record<string, unknown> },
+  res: {
+    status: (statusCode: number) => {
+      setHeader: (name: string, value: string) => unknown
+      send: (body: string) => unknown
+    }
+  },
+) {
+  const rawStageId = toSingleString(req.query.stageId)
+  const rawTitle = toSingleString(req.query.title)
+
+  const stageId = normalizeStageId(
+    rawStageId ? (safeDecodeURIComponent(rawStageId) ?? '') : '',
+  )
+  const title = normalizeTitle(rawTitle ? (safeDecodeURIComponent(rawTitle) ?? '') : '')
+  const svg = buildSvg(title, stageId)
+
+  return res
+    .status(200)
+    .setHeader('Content-Type', 'image/svg+xml; charset=utf-8')
+    .setHeader('Cache-Control', 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400')
+    .setHeader('X-Content-Type-Options', 'nosniff')
+    .send(svg)
+}

--- a/apps/frontend/api/ogp/[stageId].ts
+++ b/apps/frontend/api/ogp/[stageId].ts
@@ -1,0 +1,260 @@
+type StageSummary = {
+  id: string
+  title: string
+  playCount: number
+  clearCount: number
+  likeCount: number
+}
+
+type StageFetchResult =
+  | {
+      ok: true
+      stage: StageSummary
+    }
+  | {
+      ok: false
+      reason: string
+    }
+
+const DEFAULT_SITE_NAME = 'megalo2026'
+const DEFAULT_TITLE = 'megalo2026 | 共有ステージ'
+const DEFAULT_DESCRIPTION = 'スワイプで風を起こして遊ぶ、ステージ作成・共有ゲーム。'
+const FALLBACK_STAGE_TITLE = '未取得ステージ'
+const STAGE_FETCH_TIMEOUT_MS = 2500
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const toSingleString = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'string') {
+    return value[0]
+  }
+  return null
+}
+
+const safeDecodeURIComponent = (value: string): string | null => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return null
+  }
+}
+
+const truncate = (value: string, maxLength: number): string =>
+  value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value
+
+const escapeHtml = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+
+const getRuntimeEnv = (): Record<string, string | undefined> => {
+  const globalObject = globalThis as {
+    process?: {
+      env?: Record<string, string | undefined>
+    }
+  }
+  return globalObject.process?.env ?? {}
+}
+
+const resolveStageApiBaseUrl = (): string => {
+  const env = getRuntimeEnv()
+  const rawBaseUrl =
+    env.OGP_STAGE_API_BASE_URL ??
+    env.VITE_API_BASE_URL ??
+    env.API_BASE_URL ??
+    'http://localhost:8787'
+  return rawBaseUrl.replace(/\/+$/, '')
+}
+
+const resolveOrigin = (req: {
+  headers: Record<string, string | string[] | undefined>
+}): string => {
+  const protocol = toSingleString(req.headers['x-forwarded-proto']) ?? 'https'
+  const host =
+    toSingleString(req.headers['x-forwarded-host']) ??
+    toSingleString(req.headers.host) ??
+    'localhost:3000'
+  return `${protocol}://${host}`
+}
+
+const parseStageSummary = (value: unknown): StageSummary | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  if (
+    typeof value.id !== 'string' ||
+    typeof value.title !== 'string' ||
+    typeof value.play_count !== 'number' ||
+    typeof value.clear_count !== 'number' ||
+    typeof value.like_count !== 'number'
+  ) {
+    return null
+  }
+
+  return {
+    id: value.id,
+    title: value.title,
+    playCount: value.play_count,
+    clearCount: value.clear_count,
+    likeCount: value.like_count,
+  }
+}
+
+const fetchStageSummary = async (stageId: string): Promise<StageFetchResult> => {
+  const stageApiBaseUrl = resolveStageApiBaseUrl()
+  const stageApiUrl = `${stageApiBaseUrl}/api/stages/${encodeURIComponent(stageId)}`
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), STAGE_FETCH_TIMEOUT_MS)
+
+  let response: Response
+  try {
+    response = await fetch(stageApiUrl, {
+      signal: controller.signal,
+      headers: {
+        accept: 'application/json',
+      },
+    })
+  } catch (error) {
+    clearTimeout(timeoutId)
+    const message = error instanceof Error ? error.message : 'unknown fetch error'
+    return { ok: false, reason: `ステージAPI通信失敗: ${message}` }
+  }
+  clearTimeout(timeoutId)
+
+  if (!response.ok) {
+    const responseBody = await response.text()
+    return {
+      ok: false,
+      reason: `ステージAPI応答異常: status=${response.status}, body=${responseBody.slice(0, 200)}`,
+    }
+  }
+
+  let body: unknown
+  try {
+    body = (await response.json()) as unknown
+  } catch {
+    return { ok: false, reason: 'ステージAPIのJSONパースに失敗しました。' }
+  }
+  if (!isRecord(body)) {
+    return { ok: false, reason: 'ステージAPIのレスポンス形式が不正です。' }
+  }
+
+  const stage = parseStageSummary(body.data)
+  if (!stage) {
+    return { ok: false, reason: 'ステージ情報のパースに失敗しました。' }
+  }
+
+  return { ok: true, stage }
+}
+
+const buildHtml = (params: {
+  title: string
+  description: string
+  canonicalUrl: string
+  imageUrl: string
+  stageId: string
+  stageResolved: boolean
+}): string => {
+  const escapedTitle = escapeHtml(params.title)
+  const escapedDescription = escapeHtml(params.description)
+  const escapedCanonicalUrl = escapeHtml(params.canonicalUrl)
+  const escapedImageUrl = escapeHtml(params.imageUrl)
+  const escapedStageId = escapeHtml(params.stageId)
+
+  return `<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${escapedTitle}</title>
+    <meta name="description" content="${escapedDescription}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="${DEFAULT_SITE_NAME}" />
+    <meta property="og:title" content="${escapedTitle}" />
+    <meta property="og:description" content="${escapedDescription}" />
+    <meta property="og:url" content="${escapedCanonicalUrl}" />
+    <meta property="og:image" content="${escapedImageUrl}" />
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:title" content="${escapedTitle}" />
+    <meta property="twitter:description" content="${escapedDescription}" />
+    <meta property="twitter:image" content="${escapedImageUrl}" />
+    <link rel="canonical" href="${escapedCanonicalUrl}" />
+  </head>
+  <body>
+    <main>
+      <h1>${escapedTitle}</h1>
+      <p>${escapedDescription}</p>
+      <p>stage: ${escapedStageId}</p>
+      <p>resolved: ${params.stageResolved ? 'true' : 'false'}</p>
+      <p>stage-fetch-status: ${params.stageResolved ? 'ok' : 'fallback'}</p>
+    </main>
+  </body>
+</html>`
+}
+
+export default async function handler(
+  req: {
+    headers: Record<string, string | string[] | undefined>
+    query: Record<string, unknown>
+  },
+  res: {
+    status: (statusCode: number) => { setHeader: (name: string, value: string) => unknown; send: (body: string) => unknown }
+  },
+) {
+  const rawStageId = toSingleString(req.query.stageId)
+  const decodedStageId = rawStageId ? safeDecodeURIComponent(rawStageId) : null
+  const stageId = decodedStageId ?? ''
+  if (!stageId || decodedStageId === null) {
+    return res
+      .status(400)
+      .setHeader('Content-Type', 'text/plain; charset=utf-8')
+      .send('stageId が未指定です。')
+  }
+
+  const origin = resolveOrigin(req)
+  const playUrl = `${origin}/play/${encodeURIComponent(stageId)}`
+
+  const stageResult = await fetchStageSummary(stageId)
+  const stageTitle =
+    stageResult.ok && stageResult.stage.title.trim().length > 0
+      ? truncate(stageResult.stage.title.trim(), 80)
+      : FALLBACK_STAGE_TITLE
+
+  const title = stageResult.ok
+    ? `${stageTitle} | ${DEFAULT_SITE_NAME}`
+    : DEFAULT_TITLE
+  const description = stageResult.ok
+    ? truncate(
+        `ステージ「${stageTitle}」に挑戦しよう。play ${stageResult.stage.playCount} / clear ${stageResult.stage.clearCount} / like ${stageResult.stage.likeCount}`,
+        180,
+      )
+    : DEFAULT_DESCRIPTION
+
+  const imageUrl = `${origin}/api/ogp-image/${encodeURIComponent(stageId)}?title=${encodeURIComponent(stageTitle)}`
+  const html = buildHtml({
+    title,
+    description,
+    canonicalUrl: playUrl,
+    imageUrl,
+    stageId,
+    stageResolved: stageResult.ok,
+  })
+
+  const cacheControl = stageResult.ok
+    ? 'public, max-age=0, s-maxage=300, stale-while-revalidate=600'
+    : 'public, max-age=0, s-maxage=60'
+  return res
+    .status(200)
+    .setHeader('Content-Type', 'text/html; charset=utf-8')
+    .setHeader('Cache-Control', cacheControl)
+    .send(html)
+}

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -1,10 +1,29 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>megalo2026</title>
+    <meta
+      name="description"
+      content="スワイプで風を起こしてキャラクターを運ぶ、ステージ作成・共有ゲーム。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="megalo2026" />
+    <meta property="og:title" content="megalo2026" />
+    <meta
+      property="og:description"
+      content="スワイプで風を起こしてキャラクターを運ぶ、ステージ作成・共有ゲーム。"
+    />
+    <meta property="og:image" content="/images/ribonn_mozinasi.png" />
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:title" content="megalo2026" />
+    <meta
+      property="twitter:description"
+      content="スワイプで風を起こしてキャラクターを運ぶ、ステージ作成・共有ゲーム。"
+    />
+    <meta property="twitter:image" content="/images/ribonn_mozinasi.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/frontend/vercel.json
+++ b/apps/frontend/vercel.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/play/:stageId",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*(bot|Bot|Twitterbot|facebookexternalhit|Facebot|Slackbot-LinkExpanding|Discordbot|LineBot|LinkedInBot|WhatsApp|TelegramBot).*"
+        }
+      ],
+      "destination": "/api/ogp/:stageId"
+    }
+  ]
+}


### PR DESCRIPTION
SNSシェア用にステージごとのOGPメタ情報・画像を動的生成。
SNSクローラー判定でOGPを返すリライトルールも追加し、シェア時の見栄え向上。

Fixes #23

## 📝 背景・目的
<!-- なぜこの変更が必要なのか、何を解決するのかを簡潔に記述してください -->
<!-- 関連するIssueがある場合は、 `Close #123` のようにIssue番号を記載してください（マージ時に自動でIssueが閉じられます） -->
Close #

## 🛠 変更内容
<!-- このPRで具体的にどのような実装・修正を行ったかを箇条書きで記述してください -->
- 
- 

## ✅ 動作確認・テスト
<!-- どのような動作確認を行ったか、またはレビュアーにどう確認してほしいかを記述してください -->
<!-- UIの変更を伴う場合は、ここにスクリーンショットやGIF動画を貼ると非常に分かりやすいです -->
- [ ] 

## 🔍 レビューポイント（該当する場合）
<!-- 「ここの設計で迷った」「この処理のパフォーマンスが気になる」など、特に見てほしいポイントがあれば記述してください -->
- 

## 📋 チェックリスト
<!-- PRを提出する前に以下の項目を確認し、[x] を入れてください -->
- [ ] ビルドやテストが正常に通過すること
- [ ] 必要なドキュメントの更新を行ったこと（該当する場合）
- [ ] 不要なコメントやデバッグコードが残っていないこと